### PR TITLE
wireless: Require SSID / PSK for tests that use them

### DIFF
--- a/units/eos/tp-hw-evaluation.pxu
+++ b/units/eos/tp-hw-evaluation.pxu
@@ -57,7 +57,6 @@ include:
     #FIXME: the camera/ tests bellow do not work
     camera/display_.*                                             # C34
     camera/multiple-resolution-images_.*                          # C432
-    #FIXME: the wireless/wireless_ tests bellow do not work
     wireless/nm_connection_save_.*
     wireless/wireless_scanning_.*                                 # C35
     wireless/wireless_connection_wpa_bg_nm_.*                     # C35

--- a/units/wireless/jobs.pxu
+++ b/units/wireless/jobs.pxu
@@ -49,6 +49,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend also-after-suspend-manual
 requires:
+ environment.WPA_BG_SSID != '' and environment.WPA_BG_PSK != ''
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
  {% endif -%}
@@ -71,6 +72,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend also-after-suspend-manual
 requires:
+ environment.OPEN_BG_SSID != ''
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
  {% endif -%}
@@ -93,6 +95,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend also-after-suspend-manual
 requires:
+ environment.WPA_N_SSID != '' and environment.WPA_N_PSK != ''
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
  {% endif -%}
@@ -115,6 +118,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend also-after-suspend-manual
 requires:
+ environment.OPEN_N_SSID != ''
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
  {% endif -%}
@@ -137,6 +141,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend also-after-suspend-manual
 requires:
+ environment.WPA_AC_SSID != '' and environment.WPA_AC_PSK != ''
  wireless_sta_protocol.{{ interface }}_ac == 'supported'
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'
@@ -160,6 +165,7 @@ category_id: com.canonical.plainbox::wireless
 estimated_duration: 30.0
 flags: preserve-locale also-after-suspend also-after-suspend-manual
 requires:
+ environment.OPEN_AC_SSID != ''
  wireless_sta_protocol.{{ interface }}_ac == 'supported'
  {%- if __on_ubuntucore__ %}
  connections.slot == 'network-manager:service' and connections.plug == '{{ __system_env__["SNAP_NAME"] }}:network-manager'


### PR DESCRIPTION
Adds an explicit requirement on the environment variables that set the
SSID and password for the different wireless networks used during
certain tests. Without these variables `nmcli` gets called with empty
strings and fails, and the tests are reported as failed.

https://phabricator.endlessm.com/T27343