### PR TITLE
camera: Add gir1.2-clutter-1.0 and fswebcam as package dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,8 @@ Architecture: any
 Depends: plainbox-provider-resource-generic (>= 0.25),
          python3,
          python3-checkbox-support (>= 0.25),
+         gir1.2-clutter-1.0,
+         fswebcam,
          ${misc:Depends},
          ${plainbox:Depends},
          ${shlibs:Depends}
@@ -46,8 +48,7 @@ Recommends: bonnie++,
             smartmontools,
             sysstat,
             ${plainbox:Recommends}
-Suggests: fswebcam,
-          fwts,
+Suggests: fwts,
           glmark2,
           glmark2-es2,
           gtkperf,


### PR DESCRIPTION
The camera tests rely on having these packages installed.

https://phabricator.endlessm.com/T28177