### PR TITLE
fixup! mediacard: Do not perform I/O tests on the rootfs

### DIFF
--- a/bin/removable_storage_test
+++ b/bin/removable_storage_test
@@ -706,7 +706,7 @@ def main():
                                   if (not args.min_speed or
                                   int(test.rem_disks_speed[disk]) >=
                                   int(args.min_speed)) and
-                                  disk[1] != "/"}
+                                  disks_all[disk] != "/"}
                 if len(disks_eligible) == 0:
                     logging.error(
                         "No %s disks with speed higher than %s bits/s",


### PR DESCRIPTION
Fix checking the mount_point against '/' when generating the
disks_eligible dictionary.

https://phabricator.endlessm.com/T27342